### PR TITLE
Make remote "install" work more than once per clean build

### DIFF
--- a/targets.rake
+++ b/targets.rake
@@ -252,5 +252,6 @@ else
     end
     res = ssh "sudo #{VAR['RPI_UPDATE_OPTS']} FW_REPOLOCAL=rpi-build-archive rpi-update '#{Time.now}' 1>&2"
     info res
+    rm workdir('transfer.target')
   end
 end


### PR DESCRIPTION
Fixes #8, possibly in a slightly evil way.  But it works.
